### PR TITLE
Adds rootAttributesToPreserve property to ReplacementSwap

### DIFF
--- a/.changeset/wild-goats-bathe.md
+++ b/.changeset/wild-goats-bathe.md
@@ -1,0 +1,5 @@
+---
+"astro-vtbot": minor
+---
+
+[ReplacementSwap] Adds the ability to preserve attributes of the `<html>` root element.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A current deployment of tech demos and the documentation can be found at https:/
 
 ## !!! NEW TRICKS ✨ IN THE BAG 👜 !!!
 
+> ↹  You can now tell the  `<ReplacementSwap />` component which attributes of the `<html>`element [to preserve]() during view transitions!
+
+### Recently learned tricks ##
+
 > ⏳ [New Component](https://events-3bg.pages.dev/library/LoadingIndicator/): `<LoadingIndicator/>` is added per default when `astro-vtbot` is installed as an Astro integration with `npx astro add astro-vtbot`.
 
 > 🎥 The bag of tricks now includes [pre-built animations](https://events-3bg.pages.dev/animations/one/) that you can use with your view transitions, just like Astro's built-in `fade()` and `slide()`! Use vtbot's `zoom()` and `swing()` with Astro's `transition:animate` or enjoy completely new freedom in designing view transitions using the advanced parameterization options and the new `<AnimationStyle/>` component!

--- a/components/ReplacementSwap.astro
+++ b/components/ReplacementSwap.astro
@@ -1,14 +1,20 @@
 ---
 export interface Props {
-	preserveRootAttributes: string
+	rootAttributesToPreserve?: string;
 }
-const {preserveRootAttributes} = Astro.props;
+const { rootAttributesToPreserve = '' } = Astro.props;
 ---
-<!-- eslint-disable-next-line  -->
-<meta name="vtbot-replace-swap" content={preserveRootAttributes} />
+
+<meta name="vtbot-replace-swap" content={rootAttributesToPreserve} />
 <script>
 	import { TRANSITION_BEFORE_SWAP, isTransitionBeforeSwapEvent } from 'astro:transitions/client';
 	import { customSwap } from './swap-utils';
+
+	const TAG = 'vtbot-replace-swap';
+	const preserve = () =>
+		(document.querySelector(`meta[name="${TAG}"]`)?.getAttribute('content') ?? '')
+			.split(',')
+			.map((s) => s.trim());
 
 	document.addEventListener(TRANSITION_BEFORE_SWAP, (event) => {
 		if (isTransitionBeforeSwapEvent(event)) {
@@ -28,7 +34,7 @@ const {preserveRootAttributes} = Astro.props;
 					originalSwap();
 					return;
 				}
-				customSwap(event.newDocument, () => {
+				customSwap(event.newDocument, preserve(), () => {
 					intersection.forEach((name) => {
 						const oldEl = oldEls.find((el) => (el as HTMLElement).dataset.vtbotReplace === name);
 						const newEl = newEls.find((el) => (el as HTMLElement).dataset.vtbotReplace === name);

--- a/test/fixture/src/layouts/Layout.astro
+++ b/test/fixture/src/layouts/Layout.astro
@@ -2,13 +2,14 @@
 import { ViewTransitions } from 'astro:transitions';
 export interface Props {
 	title: string;
+	lang?: string;
 }
 
-const { title } = Astro.props;
+const { title, lang="en" } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={lang}>
 	<head>
 		<slot name="head" />
 		<ViewTransitions />

--- a/test/fixture/src/pages/repl/one.astro
+++ b/test/fixture/src/pages/repl/one.astro
@@ -3,8 +3,8 @@ import Layout from '../../layouts/Layout.astro';
 import ReplacementSwap from 'astro-vtbot/components/ReplacementSwap.astro';
 ---
 
-<Layout title="Repl1">
-	<ReplacementSwap slot="head" />
+<Layout lang="es" title="Repl1">
+	<ReplacementSwap slot="head" rootAttributesToPreserve="theme" />
 	<header data-vtbot-replace="footer">Header1</header>
 	<main data-vtbot-replace="main">Main1<a id="two" href="/repl/two/">two</a></main>
 	<a id="four" href="/repl/four/">four</a>

--- a/test/fixture/src/pages/repl/three.astro
+++ b/test/fixture/src/pages/repl/three.astro
@@ -4,8 +4,9 @@ import ReplacementSwap from 'astro-vtbot/components/ReplacementSwap.astro';
 ---
 
 <Layout title="Repl3">
-	<ReplacementSwap slot="head" />
+	<ReplacementSwap slot="head"/>
 	<header>Header3</header>
 	<main data-vtbot-replace="no main">Main3</main>
 	<footer>Footer3</footer>
-</Layout>
+	<a id="two" href="/repl/two/">two</a>
+	</Layout>

--- a/test/fixture/src/pages/repl/two.astro
+++ b/test/fixture/src/pages/repl/two.astro
@@ -3,9 +3,11 @@ import Layout from '../../layouts/Layout.astro';
 import ReplacementSwap from 'astro-vtbot/components/ReplacementSwap.astro';
 ---
 
-<Layout title="Repl2">
-	<ReplacementSwap slot="head" />
+<Layout lang="de" title="Repl2">
+	<ReplacementSwap slot="head" rootAttributesToPreserve="light, dark, none" />
 	<header>Header2</header>
-	<main data-vtbot-replace="main">Main2<a id="three" href="/repl/three/">three</a></main>
+	<main data-vtbot-replace="main">
+		Main2<a id="one" href="/repl/one/">one</a><a id="three" href="/repl/three/">three</a>
+	</main>
 	<footer>Footer2</footer>
 </Layout>

--- a/test/vt-bot.spec.ts
+++ b/test/vt-bot.spec.ts
@@ -48,12 +48,12 @@ test.describe('ReplacementSwap', () => {
 		await expect(page.locator('main')).toHaveText('Main1two');
 		await page.locator('#two').click();
 		await expect(page).toHaveTitle('Repl2');
-		await expect(page.locator('main')).toHaveText('Main2three');
+		await expect(page.locator('main')).toHaveText('Main2onethree');
 	});
 	test('falls back to original swap', async ({ page }) => {
 		await page.goto('/repl/two/');
 		await expect(page).toHaveTitle('Repl2');
-		await expect(page.locator('main')).toHaveText('Main2three');
+		await expect(page.locator('main')).toHaveText('Main2onethree');
 		await page.locator('#three').click();
 		await expect(page).toHaveTitle('Repl3');
 		await expect(page.locator('header')).toHaveText('Header3');
@@ -69,6 +69,30 @@ test.describe('ReplacementSwap', () => {
 		await expect(page).toHaveTitle('Repl4');
 		expect(await page.locator('header:above(footer)').count()).toBe(0);
 		expect(await page.locator('footer:above(header)').count()).toBe(1);
+	});
+	test('can swap lang attribute', async ({ page }) => {
+		await page.goto('/repl/one/');
+		await expect(page).toHaveTitle('Repl1');
+		expect(await (page.locator('html').getAttribute('lang'))).toBe('es');
+		await page.locator('#two').click();
+		await expect(page).toHaveTitle('Repl2');
+		expect(await (page.locator('html').getAttribute('lang'))).toBe('de');
+	});
+	test('can persist html attributes', async ({ page }) => {
+		await page.goto('/repl/one/');
+		await expect(page).toHaveTitle('Repl1');
+		await page.locator('html').evaluate((el, value) => el.setAttribute('theme', value), 'dark');
+		await page.locator('html').evaluate((el, value) => el.setAttribute('dark', value), 'very');
+		await page.locator('#two').click();
+		await expect(page).toHaveTitle('Repl2');
+		expect(await (page.locator('html').getAttribute('theme'))).toBe('dark');
+		expect(await (page.locator('html').getAttribute('dark'))).toBe(null);
+		await page.locator('html').evaluate((el, value) => el.setAttribute('theme', value), 'dark');
+		await page.locator('html').evaluate((el, value) => el.setAttribute('dark', value), 'very');
+		await page.locator('#one').click();
+		await expect(page).toHaveTitle('Repl1');
+		expect(await (page.locator('html').getAttribute('theme'))).toBe(null);
+		expect(await (page.locator('html').getAttribute('dark'))).toBe('very');
 	});
 });
 


### PR DESCRIPTION

### Description

The `<ReplacementSwap/>` component now supports the `rootAttributesToPreserve` property. Using this you can tell the swap() which root attributes to preserve during swap() ;-)

### Tests

Added two test cases 

### Docs & Examples

Updated docs in https://github.com/martrapp/astro-vtbot-website/pull/30