### PR TITLE
 Adds support for enabling view transitions for Starlight sites!

### DIFF
--- a/.changeset/large-zoos-sell.md
+++ b/.changeset/large-zoos-sell.md
@@ -1,0 +1,5 @@
+---
+"astro-vtbot": minor
+---
+
+Adds support for enabling view transitions for Starlight sites!

--- a/README.md
+++ b/README.md
@@ -11,33 +11,35 @@ A current deployment of tech demos and the documentation can be found at https:/
 
 ## !!! NEW TRICKS ✨ IN THE BAG 👜 !!!
 
-> The [animation demo](https://events-3bg.pages.dev/animations/one/) got a new row of examples featuring the new [`move()` animation](https://events-3bg.pages.dev/library/Move/)!
+### 🌟 STARLIGHT EDITION 🌟
+> The [Jotter](https://events-3bg.pages.dev/jotter/) now leverages Starlight! The beginning of a more structured and searchable version of the pile of notes that it was.
+
+> Starlight Support: Ever wanted to see what your Starlight site looks like with view transitions enabled? Follow [these steps](https://events-3bg.pages.dev/jotter/starlight/guide/) to get rid of full page loads and look like a SPA!
 
 ### Recently learned tricks ##
 
-> ↹  You can now tell the  `<ReplacementSwap />` component which attributes of the `<html>`element [to preserve](https://events-3bg.pages.dev/library/ReplacementSwap/#properties) during view transitions!
-
+> The [animation demo](https://events-3bg.pages.dev/animations/one/) got a new row of examples featuring the new [`move()` animation](https://events-3bg.pages.dev/library/Move/)!
 
 > ⏳ [New Component](https://events-3bg.pages.dev/library/LoadingIndicator/): `<LoadingIndicator/>` is added per default when `astro-vtbot` is installed as an Astro integration with `npx astro add astro-vtbot`.
-
-> 🎥 The bag of tricks now includes [pre-built animations](https://events-3bg.pages.dev/animations/one/) that you can use with your view transitions, just like Astro's built-in `fade()` and `slide()`! Use vtbot's `zoom()` and `swing()` with Astro's `transition:animate` or enjoy completely new freedom in designing view transitions using the advanced parameterization options and the new `<AnimationStyle/>` component!
 
 ## Reusable Components 🧩
 
 - In need for extensions for view transitions because you have issues with iframes on your pages?
-- Wanting support in understanding and debugging view transitions or simply want a second pair of eyes on your view transition settings?
+- Wanting support in understanding and debugging view transitions or simply want a second pair of eyes 👀 on your view transition settings?
 - Looking for reusable animations or special transition effects?
+- Want to use view transitions on your Starlight site?
 
 The `astro-vtbot`package isn't a monolithic library. Use the components you need and only pay bandwidth for those.
 |Component|Brotli bytes added|
 |-------|-----------------|
 BrakePad 🦥 | ~0.1k
-Linter 🧹 | ~2k
+Linter 🧹 | ~2.0k
 LoadingIndicator ⏳ | ~0.6k
 Move 🚟 | ~0.5k
 NoScroll 📜| ~0.1k
 Portal 🚪 | ~0.3k
 ReplacementSwap ↹ | ~0.5k
+Starlight &hellip; 🌟 | ~3.0k
 Swing 🎷 | ~0.5k
 VtBotDebug 🐛 | ~2.6k
 Zoom 🔎 | ~0.5k
@@ -66,7 +68,7 @@ The sources are in [this repository](https://github.com/martrapp/astro-vtbot-web
 
 ## The Jotter 📓
 
-Last but not least, the deployment also includes the [▶ Jotter ◀](https://events-3bg.pages.dev/docs/Jotter/) with a wealth of information on transition events as well as background information and valuable tips & tricks on view transitions in Astro.
+Last but not least, the deployment also includes the [▶ Jotter ◀](https://events-3bg.pages.dev/jotter/) with a wealth of information on transition events as well as background information and valuable tips & tricks on view transitions in Astro.
 
 Some of the contents are technical demos, some are useful tools, and some are reusable components that you can use in your own project to handle edge cases that go beyond Astro's standard features.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A current deployment of tech demos and the documentation can be found at https:/
 ### 🌟 STARLIGHT EDITION 🌟
 > The [Jotter](https://events-3bg.pages.dev/jotter/) now leverages Starlight! The beginning of a more structured and searchable version of the pile of notes that it was.
 
-> Starlight Support: Ever wanted to see what your Starlight site looks like with view transitions enabled? Follow [these steps](https://events-3bg.pages.dev/jotter/starlight/guide/) to get rid of full page loads and look like a SPA!
+> Starlight Support: Ever wanted to see what your Starlight site looks like with view transitions enabled? Follow [these steps](https://events-3bg.pages.dev/jotter/starlight/guide/) to get rid of full page loads and make your Starlight site look like a SPA!
 
 ### Recently learned tricks ##
 

--- a/components/loading-indicator.ts
+++ b/components/loading-indicator.ts
@@ -1,5 +1,6 @@
 /// <reference types="astro/client" />
 import {
+	TRANSITION_AFTER_PREPARATION,
 	TRANSITION_BEFORE_PREPARATION,
 	TRANSITION_BEFORE_SWAP,
 	TRANSITION_PAGE_LOAD,
@@ -33,7 +34,7 @@ export function initialize(onPageLoad?: () => void | Promise<void>, lowPrio = fa
 	if (!(initializer && lowPrio)) initializer = onPageLoad;
 	document.addEventListener(TRANSITION_PAGE_LOAD, doInit);
 	document.addEventListener(TRANSITION_BEFORE_PREPARATION, doShow);
-	document.addEventListener(TRANSITION_BEFORE_SWAP, doHide);
+	document.addEventListener(TRANSITION_AFTER_PREPARATION, doHide);
 }
 
 type Options = {

--- a/components/starlight/Base.astro
+++ b/components/starlight/Base.astro
@@ -1,0 +1,21 @@
+---
+import type { Props as StarlightProps } from '@astrojs/starlight/props';
+import StarlightHead from '@astrojs/starlight/components/Head.astro';
+import { ViewTransitions } from 'astro:transitions';
+
+import ReplacementSwap from '../ReplacementSwap.astro';
+import Connector from './StarlightConnector.astro';
+
+export interface Props extends StarlightProps {
+	viewTransitionsFallback: Parameters<typeof ViewTransitions>[0]['fallback'];
+}
+const mainTransitionScope = (Astro.props['data-astro-transition-scope'] as string) || 'none';
+---
+
+<StarlightHead {...Astro.props} />
+<ViewTransitions fallback={Astro.props.viewTransitionsFallback} />
+<ReplacementSwap rootAttributesToPreserve="data-theme" />
+<Connector />
+<meta name="vtbot-main-transition-scope" content={mainTransitionScope} />
+<script>
+</script>

--- a/components/starlight/Base.astro
+++ b/components/starlight/Base.astro
@@ -1,6 +1,5 @@
 ---
 import type { Props as StarlightProps } from '@astrojs/starlight/props';
-import StarlightHead from '@astrojs/starlight/components/Head.astro';
 import { ViewTransitions } from 'astro:transitions';
 
 import ReplacementSwap from '../ReplacementSwap.astro';
@@ -12,10 +11,9 @@ export interface Props extends StarlightProps {
 const mainTransitionScope = (Astro.props['data-astro-transition-scope'] as string) || 'none';
 ---
 
-<StarlightHead {...Astro.props} />
+<slot/>
 <ViewTransitions fallback={Astro.props.viewTransitionsFallback} />
 <ReplacementSwap rootAttributesToPreserve="data-theme" />
 <Connector />
 <meta name="vtbot-main-transition-scope" content={mainTransitionScope} />
-<script>
-</script>
+

--- a/components/starlight/Base.d.ts
+++ b/components/starlight/Base.d.ts
@@ -1,0 +1,1 @@
+export default function Base(_props: import('./Head.astro').Props): any;

--- a/components/starlight/StarlightConnector.astro
+++ b/components/starlight/StarlightConnector.astro
@@ -1,0 +1,87 @@
+---
+export interface Props {}
+---
+
+<script>
+	function afterLoad(e: TransitionBeforePreparationEvent) {
+		closeMobileMenu();
+		markMainFrameForReplacementSwap(document);
+		markMainFrameForReplacementSwap(e.newDocument);
+		setTransitionScope(e);
+	}
+
+	function beforeSwap(e: TransitionBeforeSwapEvent) {
+		removeCurrentPageMarker();
+		setCurrentPageMarker(e);
+	}
+
+	function closeMobileMenu() {
+		if (document.body.hasAttribute('data-mobile-menu-expanded')) {
+			document.body
+				.querySelector('starlight-menu-button')!
+				.closest('nav')!
+				.dispatchEvent(
+					new KeyboardEvent('keyup', {
+						key: 'Escape',
+						code: 'Escape',
+						charCode: 27,
+						keyCode: 27,
+						shiftKey: false,
+						ctrlKey: false,
+						altKey: false,
+						metaKey: false,
+					})
+				);
+		}
+	}
+
+	function markMainFrameForReplacementSwap(doc: Document) {
+		doc.body.querySelector('.main-frame')!.setAttribute('data-vtbot-replace', 'main');
+	}
+
+	function setTransitionScope(e: TransitionBeforePreparationEvent) {
+		const meta = document.querySelector('meta[name="vtbot-main-transition-scope"]');
+		if (!meta) return;
+		const mainTransitionScope = (meta as HTMLMetaElement).content || 'none';
+		setMainTransitionScope(document, mainTransitionScope);
+		setMainTransitionScope(e.newDocument, mainTransitionScope);
+
+		function setMainTransitionScope(doc: Document, value: string) {
+			const main = doc.querySelector('.main-frame main') as HTMLElement;
+			main && (main.dataset.astroTransitionScope = value);
+		}
+	}
+
+	function removeCurrentPageMarker() {
+		document.querySelector('[aria-current="page"]')?.removeAttribute('aria-current');
+	}
+
+	function setCurrentPageMarker(e: TransitionBeforeSwapEvent) {
+		document
+			.querySelector(`.sidebar-pane a[href="${e.to.pathname}"]`)
+			?.setAttribute('aria-current', 'page');
+	}
+
+	import {
+		TRANSITION_BEFORE_PREPARATION,
+		TRANSITION_BEFORE_SWAP,
+		TransitionBeforePreparationEvent,
+		TransitionBeforeSwapEvent,
+		isTransitionBeforePreparationEvent,
+		isTransitionBeforeSwapEvent,
+	} from 'astro:transitions/client';
+
+	document.addEventListener(TRANSITION_BEFORE_PREPARATION, (e) => {
+		if (isTransitionBeforePreparationEvent(e)) {
+			const originalLoader = e.loader;
+			e.loader = async () => {
+				await originalLoader();
+				afterLoad(e);
+			};
+		}
+	});
+
+	document.addEventListener(TRANSITION_BEFORE_SWAP, (e) => {
+		if (isTransitionBeforeSwapEvent(e)) beforeSwap(e);
+	});
+</script>

--- a/components/starlight/StarlightConnector.astro
+++ b/components/starlight/StarlightConnector.astro
@@ -53,7 +53,7 @@ export interface Props {}
 	}
 
 	function removeCurrentPageMarker() {
-		document.querySelector('[aria-current="page"]')?.removeAttribute('aria-current');
+		document.querySelector('.sidebar-pane a[aria-current="page"]')?.removeAttribute('aria-current');
 	}
 
 	function setCurrentPageMarker(e: TransitionBeforeSwapEvent) {

--- a/components/starlight/StarlightConnector.d.ts
+++ b/components/starlight/StarlightConnector.d.ts
@@ -1,0 +1,1 @@
+export default function Base(_props: import('./StarlightSetup.astro').Props): any;


### PR DESCRIPTION

### Description

Substitute Starlight's `Head` with your own `Head` that uses `compontents/starlight/Base.astro` and have view transitions enabled.

### Tests

Tested by being used for the astro-vtbot-website

### Docs & Examples

see website