### PR TITLE
Fixes an issue with the sidebar when navigating from or to pages with template:splash

### DIFF
--- a/.changeset/friendly-dragons-scream.md
+++ b/.changeset/friendly-dragons-scream.md
@@ -1,0 +1,5 @@
+---
+"astro-vtbot": patch
+---
+
+Fixes an issue with the sidebar when navigating from or to pages with template:splash

--- a/components/starlight/StarlightConnector.astro
+++ b/components/starlight/StarlightConnector.astro
@@ -11,8 +11,7 @@ export interface Props {}
 	}
 
 	function beforeSwap(e: TransitionBeforeSwapEvent) {
-		removeCurrentPageMarker();
-		setCurrentPageMarker(e);
+		updateSidebar(e);
 	}
 
 	function closeMobileMenu() {
@@ -36,7 +35,7 @@ export interface Props {}
 	}
 
 	function markMainFrameForReplacementSwap(doc: Document) {
-		doc.body.querySelector('.main-frame')!.setAttribute('data-vtbot-replace', 'main');
+		doc.body.querySelector('div.main-frame')!.setAttribute('data-vtbot-replace', 'main');
 	}
 
 	function setTransitionScope(e: TransitionBeforePreparationEvent) {
@@ -52,14 +51,24 @@ export interface Props {}
 		}
 	}
 
-	function removeCurrentPageMarker() {
-		document.querySelector('.sidebar-pane a[aria-current="page"]')?.removeAttribute('aria-current');
-	}
-
-	function setCurrentPageMarker(e: TransitionBeforeSwapEvent) {
-		document
-			.querySelector(`.sidebar-pane a[href="${e.to.pathname}"]`)
-			?.setAttribute('aria-current', 'page');
+	function updateSidebar(e: TransitionBeforeSwapEvent) {
+		const newSidebar = e.newDocument.querySelector('nav.sidebar');
+		if (!newSidebar) {
+			document.querySelector('nav.sidebar')?.remove();
+		} else {
+			const sidebar = document.querySelector('nav.sidebar');
+			if (!sidebar) {
+				document.querySelector('div.main-frame')?.insertAdjacentElement('beforebegin', newSidebar);
+			} else {
+				const oldContent = sidebar.querySelector('.sidebar-content');
+				const newContent = newSidebar.querySelector('.sidebar-content');
+				if (oldContent && newContent) {
+					oldContent.replaceWith(newContent);
+				} else {
+					sidebar.replaceWith(newSidebar);
+				}
+			}
+		}
 	}
 
 	import {

--- a/components/starlight/StarlightConnector.d.ts
+++ b/components/starlight/StarlightConnector.d.ts
@@ -1,1 +1,1 @@
-export default function Base(_props: import('./StarlightSetup.astro').Props): any;
+export default function Base(_props: import('./StarlightConnector.astro').Props): any;


### PR DESCRIPTION

### Description

Fixes an issue with the sidebar when navigating from or to pages with `template:splash`.
Fixes #55

### Tests

The former solution only updated the current page in the sidebar. It didn't take into account that pages with `template: splash` do not have sidebars. No the sidebar is removes and restored when navigating between pages with and without sidebars.


### Docs & Examples

Tested manually with a splash page on the vtbot website and the example from #55