### PR TITLE
Honor  when listing which scripts might run.

### DIFF
--- a/.changeset/little-dragons-itch.md
+++ b/.changeset/little-dragons-itch.md
@@ -1,0 +1,5 @@
+---
+"astro-vtbot": patch
+---
+
+Honor `data-astro-rerun` when listing which scripts might run.

--- a/components/VtBotDebug.astro
+++ b/components/VtBotDebug.astro
@@ -90,7 +90,7 @@ const active = import.meta.env.DEV || production;
 			css.push(BOLD);
 			css.push(NORMAL);
 		}
-		prefix[usePrefix ? "log": "slog"](s, ...css);
+		prefix[usePrefix ? 'log' : 'slog'](s, ...css);
 	};
 
 	/*
@@ -234,7 +234,7 @@ const active = import.meta.env.DEV || production;
 		const scriptsArray = [...scripts];
 		const toExecute = scriptsArray.filter(
 			(s) =>
-				s.dataset.astroExec !== '' &&
+				(s.dataset.astroExec !== '' || s.dataset.astroRerun) &&
 				(!s.type || s.type === 'module' || s.type === 'text/javascript') &&
 				(s.type !== 'module' || !knownModuleScripts.has(s.src))
 		);


### PR DESCRIPTION
The listing of scripts to be executed between `astro:after-swap` and `astro:page-load` ignored scripts with `data-astro-rerun` a attribute. Fixed that.
