### PR TITLE
Add PageOrder

### DIFF
--- a/.changeset/sweet-pets-remember.md
+++ b/.changeset/sweet-pets-remember.md
@@ -1,0 +1,6 @@
+---
+"astro-vtbot": patch
+---
+
+PageOrder: adds a new component to the Starlight support that changes the direction of the transition based on the order of the pages in the sidebar.
+

--- a/README.md
+++ b/README.md
@@ -16,22 +16,23 @@ A current deployment of tech demos and the documentation can be found at https:/
 
 The selection of optional Starlight components keeps growing:
 
-> Eliminate the Pseudo-Scrolling of the Main Section: With [`<PageOffset />`](https://events-3bg.pages.dev/library/PageOffset/), The Bag offers a simple to use component that eliminates pseudo scrolling effects induced by morph tranistions on elements that are larger than the viewport. Especially usfull to get a smooth and neat transition animation for your main content.
+> Ever wished clicking on Starlight's _previous page_ and _next page_ links would slide content from the left respectively from the right?  Now you can enable `<PageOrder />` on Starlight sites. This automatically alters the _direction_ of the view transition. Visit a page further down the sidebar and get a _forward_ navigation, visit a page further up, and you get a _back_ navigation.
+
+> Eliminate the Pseudo-Scrolling of the Main Section: With [`<PageOffset />`](https://events-3bg.pages.dev/library/PageOffset/), The Bag offers a simple to use component that eliminates pseudo scrolling effects induced by morph transitions on elements that are larger than the viewport. Especially useful to get a smooth and neat transition animation for your main content.
 
 > Improved Sidebar Handling: When you navigate to a page that has its entry within a collapsed category, the category is now automatically turned open. If the current page marker is outside the visible
 part of the sidebar, it is automatically scrolled into view. **New: Support for your own customizations!**
 
+## Recently learned tricks ##
+
 > If you want to use `transition:persist` inside the main content area, you can do that now! As of v1.7.8 the `<ReplacementSwap />` component handles `data-astro-transition-persist` attributes within the replaced DOM trees in the same way as Astro's built-in `swap()` function does.
 
-### Recently learned tricks ##
 
-### 🌟 STARLIGHT EDITION 🌟
 > The [Jotter](https://events-3bg.pages.dev/jotter/) now leverages Starlight! The beginning of a more structured and searchable version of the pile of notes that it was.
 
 > Starlight Support: Ever wanted to see what your Starlight site looks like with view transitions enabled? Follow [these steps](https://events-3bg.pages.dev/jotter/starlight/guide/) to get rid of full page loads and make your Starlight site look like a SPA!
 
 
-> The [animation demo](https://events-3bg.pages.dev/animations/one/) got a new row of examples featuring the new [`move()` animation](https://events-3bg.pages.dev/library/Move/)!
 
 
 ## Reusable Components 🧩
@@ -45,13 +46,13 @@ The `astro-vtbot`package isn't a monolithic library. Use the components you need
 |Component|Brotli bytes added|
 |-------|-----------------|
 Animation Style ✨| ~0.1k
-BrakePad 🦥 | ~0.1k
-Linter 🧹 | ~1.6k
-LoadingIndicator ⏳ | ~0.2k
+BrakePad 🦥 | ~0.2k
+Linter 🧹 | ~1.9k
+LoadingIndicator ⏳ | ~0.4k
 Move 🚟 | ~0.2k
 NoScroll 📜 | ~0.1k
-PageOffset 📄⇞ | ~0.2k
-Portal 🚪 | ~0.1k
+PageOffset 📄⇞ | ~0.1k
+Portal 🚪 | ~0.2k
 ReplacementSwap ↹ | ~0.5k
 Starlight &hellip; 🌟 | ~3.0k
 Swing 🎷 | ~0.1k

--- a/components/starlight/PageOrder.astro
+++ b/components/starlight/PageOrder.astro
@@ -1,0 +1,29 @@
+---
+export interface Props {}
+---
+
+<script>
+	import {
+		isTransitionBeforePreparationEvent,
+		TRANSITION_BEFORE_PREPARATION,
+	} from 'astro:transitions/client';
+	import {SIDEBAR_TOPLEVEL as STARLIGHT_SIDEBAR_TOPLEVEL} from './utils';
+	document.addEventListener(TRANSITION_BEFORE_PREPARATION, (e) => {
+		const pages = [...document.querySelectorAll(`${STARLIGHT_SIDEBAR_TOPLEVEL} a`)].map(
+			(a) => new URL((a as HTMLAnchorElement).href).pathname
+		);
+		if (isTransitionBeforePreparationEvent(e)) {
+			const fromIdx = pages.indexOf(e.from.pathname);
+			const toIdx = pages.indexOf(e.to.pathname);
+
+			e.direction =
+				fromIdx === -1 || toIdx === -1
+					? e.direction
+					: fromIdx === toIdx
+						? 'stay'
+						: fromIdx < toIdx
+							? 'forward'
+							: 'back';
+		}
+	});
+</script>

--- a/components/starlight/PageOrder.d.ts
+++ b/components/starlight/PageOrder.d.ts
@@ -1,0 +1,1 @@
+export default function PageOrder(_props: import('./PageOrder.astro').Props): any;

--- a/components/starlight/utils.ts
+++ b/components/starlight/utils.ts
@@ -4,6 +4,7 @@ export const MOBILE_MENU_EXPANDED = 'data-mobile-menu-expanded';
 export const MENU_BUTTON = 'starlight-menu-button';
 export const SIDEBAR = 'nav.sidebar';
 export const SIDEBAR_CONTENT = `${SIDEBAR} .sidebar-content`;
+export const SIDEBAR_TOPLEVEL = `${SIDEBAR_CONTENT} .top-level`;
 
 /*
  * Returns the the sidebar anchor that best fits the parameter URL.


### PR DESCRIPTION
### Description

PageOrder changes the direction of the transition depending on the order of pages in the sidebar.

### Tests

Used on the Jotter and tested with Starlight

### Docs & Examples

Added component description to the guide