### PR TITLE
Better strategy to find an icon if none is configured

### DIFF
--- a/.changeset/rich-onions-hunt.md
+++ b/.changeset/rich-onions-hunt.md
@@ -1,0 +1,5 @@
+---
+"astro-vtbot": patch
+---
+
+LoadingIndicator: Improves the way the loading indicator tries to find an icon to display.

--- a/components/loading-indicator.ts
+++ b/components/loading-indicator.ts
@@ -10,19 +10,19 @@ let show: () => void;
 let hide: () => void;
 let initializer: (() => void | Promise<void>) | undefined;
 
-export function loading(newShow: () => void, newHide: () => void, newInit: () => void = () => {}) {
+export function loading(newShow: () => void, newHide: () => void, newInit: () => void = () => { }) {
 	show = newShow;
 	hide = newHide;
 	initialize(newInit);
 }
 
 const doShow = () => {
-	document.documentElement.classList.add(`loading`);
+	document.documentElement.classList.add('loading');
 	show && show();
 };
 
 const doHide = () => {
-	document.documentElement.classList.remove(`loading`);
+	document.documentElement.classList.remove('loading');
 	hide && hide();
 };
 
@@ -49,10 +49,8 @@ export async function vtbotLoadingIndicator(options: Options) {
 	const loadingIndicator = document.getElementById('vtbot-loading-indicator');
 	if (loadingIndicator) return;
 
-	const favicon =
-		(options.src ||
-			(document.querySelector(`link[rel*="icon"]:last-of-type`) as HTMLLinkElement)?.href) ??
-		'/favicon.ico';
+	const icons = options.src ? [] : document.querySelectorAll<HTMLLinkElement>(`head link[rel*="icon"]`);
+	const favicon = (options.src || (icons[icons.length - 1])?.href) ?? '/favicon.ico';
 
 	let src = '';
 	try {


### PR DESCRIPTION
### Description

The original CSS selector was incorrect.
Replaced it with something simpler & querySelectorAll()[-1]

### Tests

Manually tested, no kind of works with blog template. 

### Docs & Examples

Bug fix, n.a.