### PR TITLE
Log astro:after-preparation

### DIFF
--- a/.changeset/slimy-eggs-act.md
+++ b/.changeset/slimy-eggs-act.md
@@ -1,0 +1,5 @@
+---
+"astro-vtbot": patch
+---
+
+VtBotDebug: Fixes an issue where `astro:after-preparation` was not logged at all.

--- a/components/VtBotDebug.astro
+++ b/components/VtBotDebug.astro
@@ -376,13 +376,11 @@ const active = import.meta.env.DEV || production;
 		}
 	}
 
-	function afterPreparation(): EventListenerOrEventListenerObject {
-		return (e) => {
-			if (enabled_out()) {
-				logProperties(window._vtbot_debug.capture.event, true);
-				prefix.log(`Event handler for ${e.type}`);
-			}
-		};
+	function afterPreparation(e:Event) {
+		if (enabled_out()) {
+			logProperties(window._vtbot_debug.capture.event, true);
+			prefix.log(`Event handler for ${e.type}`);
+		}
 	}
 
 	function beforeSwap(swapEvent: Event) {


### PR DESCRIPTION
The handler for `astro:after-preparation` was literally dead in `VtBotDebug`. Fixed that.
