### PR TITLE
Fixes an issue where switching languages did select a different page.

### DIFF
--- a/.changeset/late-cougars-taste.md
+++ b/.changeset/late-cougars-taste.md
@@ -1,0 +1,5 @@
+---
+"astro-vtbot": patch
+---
+
+Fixes an issue where switching languages did select a different page.

--- a/components/starlight/StarlightConnector.astro
+++ b/components/starlight/StarlightConnector.astro
@@ -103,7 +103,7 @@
 		doc
 			.querySelectorAll(STARLIGHT.LANGUAGE_SELECTOR)
 			.forEach((el, idx) =>
-				el.setAttribute('data-vtbot-replace', STARLIGHT.LANGUAGE_SELECTOR + idx)
+				el.setAttribute('data-vtbot-replace', `vtbot-${STARLIGHT.LANGUAGE_SELECTOR}-${idx}`)
 			);
 	}
 

--- a/components/starlight/StarlightConnector.astro
+++ b/components/starlight/StarlightConnector.astro
@@ -11,18 +11,24 @@
 
 	const queryMarkers = () => ({
 		replaceSidebarContent: document.querySelector(`head meta[name="${REPLACE_SIDEBAR_CONTENT}"]`),
-		retainCurrentPageMarker: document.querySelector(`head meta[name="${RETAIN_CURRENT_PAGE_MARKER}"]`),
+		retainCurrentPageMarker: document.querySelector(
+			`head meta[name="${RETAIN_CURRENT_PAGE_MARKER}"]`
+		),
 
-		mainTransitionScope:  document.querySelector<HTMLMetaElement>('head meta[name="vtbot-main-transition-scope"]')?.content,
+		mainTransitionScope: document.querySelector<HTMLMetaElement>(
+			'head meta[name="vtbot-main-transition-scope"]'
+		)?.content,
 	});
 	let { replaceSidebarContent, retainCurrentPageMarker, mainTransitionScope } = queryMarkers();
 
 	openCategory();
+	updateLanguageSelector(window.document);
 
 	function afterLoader(e: TransitionBeforePreparationEvent) {
 		markMainFrameForReplacementSwap(document);
 		markMainFrameForReplacementSwap(e.newDocument);
 		closeMobileMenu();
+		updateLanguageSelector(e.newDocument);
 		setMainTransitionScope(e);
 		!replaceSidebarContent && !retainCurrentPageMarker && updateCurrentPageMarker(e.to);
 	}
@@ -91,6 +97,14 @@
 				}
 			}
 		}
+	}
+
+	function updateLanguageSelector(doc: Document) {
+		doc
+			.querySelectorAll(STARLIGHT.LANGUAGE_SELECTOR)
+			.forEach((el, idx) =>
+				el.setAttribute('data-vtbot-replace', STARLIGHT.LANGUAGE_SELECTOR + idx)
+			);
 	}
 
 	/*--------------------------*/

--- a/components/starlight/utils.ts
+++ b/components/starlight/utils.ts
@@ -5,6 +5,7 @@ export const MENU_BUTTON = 'starlight-menu-button';
 export const SIDEBAR = 'nav.sidebar';
 export const SIDEBAR_CONTENT = `${SIDEBAR} .sidebar-content`;
 export const SIDEBAR_TOPLEVEL = `${SIDEBAR_CONTENT} .top-level`;
+export const LANGUAGE_SELECTOR = 'starlight-lang-select';
 
 /*
  * Returns the the sidebar anchor that best fits the parameter URL.


### PR DESCRIPTION
### Description

The value in the `starlight-lang-select` custom element changes between pages.
As it sits in the app frame, it did not get refreshed and kept the reference to the first visited page. Adding `data-vtbot-replace` attributes fixes this issue.  

### Tests

Manually tested

### Docs & Examples

