### PR TITLE
refector for Astro 4.8 with backward compatibility

### DIFF
--- a/.changeset/tender-flowers-guess.md
+++ b/.changeset/tender-flowers-guess.md
@@ -1,0 +1,5 @@
+---
+"astro-vtbot": patch
+---
+
+Starting with Astro 4.8, The Bag's swap-utils are obsolete and deprecated.

--- a/components/ReplacementSwap.astro
+++ b/components/ReplacementSwap.astro
@@ -7,8 +7,8 @@ const { rootAttributesToPreserve = '' } = Astro.props;
 
 <meta name="vtbot-replace-swap" content={rootAttributesToPreserve} />
 <script>
-	import { TRANSITION_BEFORE_SWAP, isTransitionBeforeSwapEvent } from 'astro:transitions/client';
-	import { customSwap, astroBodySwap } from './swap-utils';
+	import { TRANSITION_BEFORE_SWAP } from 'astro:transitions/client';
+	import { swapFunctions } from './swap-utils-connector';
 
 	const TAG = 'vtbot-replace-swap';
 	const preserve = () =>
@@ -17,37 +17,45 @@ const { rootAttributesToPreserve = '' } = Astro.props;
 			.map((s) => s.trim());
 
 	document.addEventListener(TRANSITION_BEFORE_SWAP, (event) => {
-		if (isTransitionBeforeSwapEvent(event)) {
-			const originalSwap = event.swap;
-			event.swap = () => {
-				const replacements = (document: Document) => {
-					const elements = document.body.querySelectorAll('[data-vtbot-replace]');
-					const names = [...elements].map(
-						(el) => el instanceof HTMLElement && el.dataset.vtbotReplace
-					);
-					return { elements: [...elements], names: new Set(names) };
-				};
-				const { elements: oldEls, names: oldNames } = replacements(document);
-				const { elements: newEls, names: newNames } = replacements(event.newDocument);
-				const intersection = [...oldNames].filter((name) => newNames.has(name));
-				if (intersection.length === 0) {
-					originalSwap();
-					return;
-				}
-				customSwap(event.newDocument, preserve(), () => {
-					intersection.forEach((name) => {
-						const oldEl = oldEls.find((el) => (el as HTMLElement).dataset.vtbotReplace === name);
-						const newEl = newEls.find((el) => (el as HTMLElement).dataset.vtbotReplace === name);
-						if (oldEl && newEl) {
-							astroBodySwap(oldEl, newEl);
-						}
-					});
-					[...document.querySelectorAll("[class*='astro-route-announcer']")].forEach((e) =>
-						e.remove()
-					);
-				});
+		const originalSwap = event.swap;
+		event.swap = () => {
+			const replacements = (document: Document) => {
+				const elements = document.body.querySelectorAll('[data-vtbot-replace]');
+				const names = [...elements].map(
+					(el) => el instanceof HTMLElement && el.dataset.vtbotReplace
+				);
+				return { elements: [...elements], names: new Set(names) };
 			};
-		}
-	});
+			const { elements: oldEls, names: oldNames } = replacements(document);
+			const { elements: newEls, names: newNames } = replacements(event.newDocument);
+			const intersection = [...oldNames].filter((name) => newNames.has(name));
+			if (intersection.length === 0) {
+				originalSwap();
+				return;
+			}
+			const doc = event.newDocument;
+			swapFunctions.deselectScripts(doc);
+			const preservedAttributes = preserve().map((n) => ({
+				key: n,
+				val: document.documentElement.getAttribute(n),
+			}));
+			swapFunctions.swapRootAttributes(doc);
+			preservedAttributes.forEach(
+				(attr) => attr.val !== null && document.documentElement.setAttribute(attr.key, attr.val)
+			);
+			swapFunctions.swapHeadElements(doc);
+			const restore = swapFunctions.saveFocus();
 
+			intersection.forEach((name) => {
+				const oldEl = oldEls.find((el) => (el as HTMLElement).dataset.vtbotReplace === name);
+				const newEl = newEls.find((el) => (el as HTMLElement).dataset.vtbotReplace === name);
+				if (oldEl && newEl) {
+					swapFunctions.swapBodyElement(newEl, oldEl);
+				}
+			});
+			restore();
+
+			[...document.querySelectorAll("[class*='astro-route-announcer']")].forEach((e) => e.remove());
+		};
+	});
 </script>

--- a/components/swap-utils-connector.ts
+++ b/components/swap-utils-connector.ts
@@ -1,0 +1,20 @@
+import { astroBodySwap, customSwap, disarmKnownScripts, restoreFocus, saveFocus, swapInHeadElements, swapInHTMLAttributes } from "./swap-utils";
+
+export let swapFunctions = {
+	deselectScripts: disarmKnownScripts,
+	swapRootAttributes: (doc: Document) => swapInHTMLAttributes(doc, []),
+	swapHeadElements: swapInHeadElements,
+	swapBodyElement: (newEl: Element, oldEl: Element) => astroBodySwap(oldEl, newEl),
+	saveFocus: () => { const storedFocus = saveFocus(); return () => restoreFocus(storedFocus); },
+	restoreFocus,
+	swap: (doc: Document) => customSwap(doc, [], (doc) => astroBodySwap(document.body, doc.body))
+};
+
+const hideFromVite = "../../astro/dist/transitions/swap-functions.js";
+
+try {
+	const builtInFunctions = await import(hideFromVite);
+	swapFunctions = builtInFunctions;
+} catch (e) {
+	// no Astro peer >= 4.8 found. Keep our fallback implementation
+}

--- a/components/swap-utils.ts
+++ b/components/swap-utils.ts
@@ -1,3 +1,8 @@
+/*
+ * These functions are deprecated.
+ * Starting from Astro 4.8, please have a look at astro/dist/transitions/swap-functions.js
+ */
+
 const PERSIST_ATTR = 'data-astro-transition-persist';
 
 type SavedFocus = {


### PR DESCRIPTION

### Description

Starting from 4.8 the swap-utils are obsolete and deprecated. 

### Tests

Manually tested

### Docs & Examples

updated website