### PR TITLE
switch inspection chamber script from inline to external

### DIFF
--- a/.changeset/ninety-cherries-rule.md
+++ b/.changeset/ninety-cherries-rule.md
@@ -1,0 +1,5 @@
+---
+'astro-vtbot': patch
+---
+
+Greatly reduces the footprint of the Chamber in HTML files when used via the integration option.

--- a/integration/astro-inspection-chamber.js.ts
+++ b/integration/astro-inspection-chamber.js.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
+import { readFileSync } from 'node:fs';
 
-const inspectionChamber = readFileSync("node_modules/@vtbag/inspection-chamber/lib/index.js");
+const inspectionChamber = readFileSync('node_modules/@vtbag/inspection-chamber/lib/index.js');
 
 export async function GET({ params, request }) {
 	return new Response(

--- a/integration/astro-inspection-chamber.js.ts
+++ b/integration/astro-inspection-chamber.js.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from "node:fs";
+
+const inspectionChamber = readFileSync("node_modules/@vtbag/inspection-chamber/lib/index.js");
+
+export async function GET({ params, request }) {
+	return new Response(
+		`if (sessionStorage.getItem('vtbot-inspection-chamber') === 'true') {${inspectionChamber}};`
+	);
+}

--- a/integration/index.ts
+++ b/integration/index.ts
@@ -4,7 +4,6 @@ import vitePluginVtbotExtend from './vite-plugin-extend';
 import icon from '../assets/bag-of-tricks-mono.svg?raw';
 import { fileURLToPath } from 'node:url';
 
-
 type VtBotOptions = {
 	autoLint?: boolean;
 	loadingIndicator?: boolean;
@@ -27,7 +26,6 @@ export default function createIntegration(options?: VtBotOptions): AstroIntegrat
 
 				//@ts-expect-error
 				if (import.meta.env.DEV) {
-
 					setupOptions.injectRoute({
 						pattern: '/_vtbot_inspection_chamber.js',
 						entrypoint: 'node_modules/astro-vtbot/integration/astro-inspection-chamber.js.ts',
@@ -45,7 +43,6 @@ export default function createIntegration(options?: VtBotOptions): AstroIntegrat
 					icon,
 					entrypoint: fileURLToPath(new URL('../devToolbar/app.ts', import.meta.url)),
 				});
-
 			},
 		},
 	};

--- a/integration/index.ts
+++ b/integration/index.ts
@@ -2,10 +2,8 @@ import type { AstroIntegration } from 'astro';
 import vitePluginVtbotExtend from './vite-plugin-extend';
 //@ts-expect-error
 import icon from '../assets/bag-of-tricks-mono.svg?raw';
-import inspectionChamber from '@vtbag/inspection-chamber?raw';
 import { fileURLToPath } from 'node:url';
 
-const DTB_TOKEN = 'vtbot-inspection-chamber';
 
 type VtBotOptions = {
 	autoLint?: boolean;
@@ -26,18 +24,18 @@ export default function createIntegration(options?: VtBotOptions): AstroIntegrat
 						},
 					});
 				}
+
 				//@ts-expect-error
 				if (import.meta.env.DEV) {
+
 					setupOptions.injectRoute({
-						pattern: '/_vtbot_inspection_chamber',
-						entrypoint: 'node_modules/astro-vtbot/components/InspectionChamber.astro',
+						pattern: '/_vtbot_inspection_chamber.js',
+						entrypoint: 'node_modules/astro-vtbot/integration/astro-inspection-chamber.js.ts',
 					});
 
 					setupOptions.injectScript(
 						'head-inline',
-						`if (sessionStorage.getItem('${DTB_TOKEN}') === 'true') {${inspectionChamber}};
-						const script = document.currentScript;
-						setTimeout(script.remove(), 1000)`
+						`(function() {var s=document.createElement('script');s.src='/_vtbot_inspection_chamber.js';document.head.appendChild(s);var t=document.currentScript;setTimeout(()=>{t.remove();s.remove()},1000)})();`
 					);
 				}
 
@@ -47,6 +45,7 @@ export default function createIntegration(options?: VtBotOptions): AstroIntegrat
 					icon,
 					entrypoint: fileURLToPath(new URL('../devToolbar/app.ts', import.meta.url)),
 				});
+
 			},
 		},
 	};


### PR DESCRIPTION
### Description

Reduced footprint:
Before, the integration via the devToolbar inlined the chamber script. 
Now its done using an external script. 

### Tests

via @vtbag/website

### Docs & Examples

n.a.