### PR TITLE
Fix runtime error when installing with pnpm

### DIFF
--- a/.changeset/six-spiders-design.md
+++ b/.changeset/six-spiders-design.md
@@ -1,0 +1,5 @@
+---
+'astro-vtbot': patch
+---
+
+fixes `inspectionChamber` endpoint runtime error when using `pnpm`

--- a/integration/astro-inspection-chamber.js.ts
+++ b/integration/astro-inspection-chamber.js.ts
@@ -1,4 +1,5 @@
-import inspectionChamber from '@vtbag/inspection-chamber/lib/index.js?raw';
+import "astro/client";
+import inspectionChamber from "@vtbag/inspection-chamber?raw";
 
 export async function GET({ params, request }) {
 	return new Response(

--- a/integration/astro-inspection-chamber.js.ts
+++ b/integration/astro-inspection-chamber.js.ts
@@ -1,6 +1,4 @@
-import { readFileSync } from 'node:fs';
-
-const inspectionChamber = readFileSync('node_modules/@vtbag/inspection-chamber/lib/index.js');
+import inspectionChamber from '@vtbag/inspection-chamber/lib/index.js?raw';
 
 export async function GET({ params, request }) {
 	return new Response(


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to the astro-vtbot package!  -->
### Description

 - changes `readFileSync` to `raw` vite import to prevent error when installing astro-vtbot with pnpm
 - fixes #199 

### Tests

- TBD

@martrapp thanks for helping me with testing :)

### Docs & Examples

- just bugfix
