### PR TITLE
fix: resolve relative paths for compatibility with pnpm hoisting

### DIFF
--- a/.changeset/strange-swans-destroy.md
+++ b/.changeset/strange-swans-destroy.md
@@ -2,4 +2,5 @@
 'astro-vtbot': patch
 ---
 
+-- **Thank you [Luísa](https://github.com/luisaverza)** -- for fixing the plugin integration for monorepos with `pnpm`!\
 fix: resolve relative paths for compatibility with pnpm hoisting

--- a/.changeset/strange-swans-destroy.md
+++ b/.changeset/strange-swans-destroy.md
@@ -1,0 +1,5 @@
+---
+'astro-vtbot': patch
+---
+
+fix: resolve relative paths for compatibility with pnpm hoisting

--- a/integration/index.ts
+++ b/integration/index.ts
@@ -3,7 +3,7 @@ import vitePluginVtbotExtend from './vite-plugin-extend';
 
 import icon from '../assets/bag-of-tricks-mono.svg?raw';
 import { fileURLToPath } from 'node:url';
-import path from 'path';
+import path from 'node:path';
 
 type VtBotOptions = {
 	autoLint?: boolean;

--- a/integration/index.ts
+++ b/integration/index.ts
@@ -3,6 +3,7 @@ import vitePluginVtbotExtend from './vite-plugin-extend';
 
 import icon from '../assets/bag-of-tricks-mono.svg?raw';
 import { fileURLToPath } from 'node:url';
+import path from 'path';
 
 type VtBotOptions = {
 	autoLint?: boolean;
@@ -27,7 +28,10 @@ export default function createIntegration(options?: VtBotOptions): AstroIntegrat
 				if (import.meta.env.DEV) {
 					setupOptions.injectRoute({
 						pattern: '/_vtbot_inspection_chamber.js',
-						entrypoint: 'node_modules/astro-vtbot/integration/astro-inspection-chamber.js.ts',
+						entrypoint: path.resolve(
+							fileURLToPath(import.meta.url),
+							'../astro-inspection-chamber.js.ts'
+						),
 					});
 
 					setupOptions.injectScript(


### PR DESCRIPTION
## What does this PR do?
This PR fixes a hardcoded path resolution issues in the `astro-vtbot` package that caused compatibility problems with `pnpm`'s symlinked/hoisted dependency structure.

### Problem
- `astro-vtbot` previously used hardcoded file paths like `'node_modules/astro-vtbot/integration/astro-inspection-chamber.js.ts'` to resolve internal files. These paths assumed a flat `node_modules` directory structure.
- When using `pnpm`, which organizes dependencies via symlinks and hoisting to a shared store, these hardcoded paths broke, leading to runtime errors (`ENOENT`, "no such file or directory").

### Solution
- Replaced hardcoded path with dynamic resolution using `import.meta.url` and `path.resolve()`, ensuring compatibility with `pnpm` and other modern package managers.

### Testing
I verified that the package loads correctly in a `pnpm` monorepo and resolves paths dynamically.

### Why is this important?
These changes improve compatibility with popular tools like `pnpm`, making it easier to integrate `astro-vtbot` into monorepo projects and other modern setups.
