### PR TITLE
Fix stuff

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -1,5 +1,8 @@
 name: Run Checks
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/martrapp/astro-vtbot/security/code-scanning/2](https://github.com/martrapp/astro-vtbot/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow. Since the workflow does not appear to require write access, the permissions can be set to `contents: read`, which is the minimal privilege required for workflows that do not modify repository contents. This block can be added at the root level of the workflow to apply to all jobs, or specifically to the `test` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
