### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,7 @@
 
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/martrapp/astro-vtbot/security/code-scanning/3](https://github.com/martrapp/astro-vtbot/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, the workflow primarily performs tasks like checking out the repository, setting up Node.js, caching dependencies, installing dependencies, and running tests. These tasks only require `contents: read` permission. Therefore, we will set the `permissions` block to restrict access to `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
